### PR TITLE
Add quotes around file path to fix bug when path contains spaces.

### DIFF
--- a/todo.actions.d/edit
+++ b/todo.actions.d/edit
@@ -9,6 +9,6 @@ case $1 in
   ;;
 *)
   FILE=${2:-todo}.txt
-  $EDITOR $TODO_DIR/$FILE
+  $EDITOR "$TODO_DIR/$FILE"
   ;;
 esac


### PR DESCRIPTION
My $TODO_DIR contained a space and was not compatible with this plugin. Just adding quotes to fix this.
