### PR TITLE
Tolerate paths with spaces

### DIFF
--- a/todo.actions.d/edit
+++ b/todo.actions.d/edit
@@ -8,7 +8,7 @@ case $1 in
 *)
   FILE=${2:-todo}.txt
   if [ -n "$EDITOR" ]; then
-    $EDITOR $TODO_DIR/$FILE
+    $EDITOR "$TODO_DIR/$FILE"
   else
     echo "Error: The EDITOR environment variable is not set"
   fi


### PR DESCRIPTION
The issue occurs if a given user has a personal and business Dropbox.
Dropbox itself names folders as `~/Dropbox (Personal)` and `~/Dropbox (YourCompany)',
making your editor edit 2 files in this case.